### PR TITLE
Edit GetToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Helper library for [Auth0 Management API](https://auth0.com/docs/api/management/
 All requests to the Management API need to use a token, you can get one using the `GetToken` method.
 
 ```
-token, err := auth0.GetToken("client_id", "client_secret", "https://mock.auth0.com/api/v2/")
+token, err := auth0.GetToken("client_id", "client_secret", "https://mock.auth0.com/api/v2/", "mock.auth0.com")
 
 fmt.Println(token.AccessToken)
 // outputs eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlFqUTVORG[...]
@@ -22,7 +22,7 @@ You can create a `Client` which will keep the token fresh and automatically corr
 For example, to call the [Create Users](https://auth0.com/docs/api/management/v2#!/Users/post_users) endpoint...
 
 ```
-c, _ := auth0.NewClient("client_id", "client_secret", "https://mock.auth0.com/api/v2/")
+c, _ := auth0.NewClient("client_id", "client_secret", "https://mock.auth0.com/api/v2/", "mock.auth0.com")
 
 var res interface{}
 
@@ -54,7 +54,8 @@ For methods that *have* been wired up, it's easier -
 c, err := auth0.NewClient(
     "client id",
     "client secret",
-    "https://mock.auth0.com/api/v2/")
+    "https://mock.auth0.com/api/v2/", 
+    "mock.auth0.com")
 
 u, err := c.UserCreate(&auth0.UserCreateParams{
     Email:         "nick.bradshaw@us.navy.mil",

--- a/client.go
+++ b/client.go
@@ -161,5 +161,7 @@ func (c *Client) request(method, endpoint string, params map[string]string, body
 		fmt.Printf("RESPONSE: %s\n", string(resBody))
 	}
 
+	logrus.WithField("res", res).Info("Response")
+
 	return resBody, nil
 }

--- a/client.go
+++ b/client.go
@@ -17,15 +17,15 @@ type Client struct {
 	ClientID     string
 	ClientSecret string
 	Audience     string
-	Endpoint     string
+	Domain       string
 	token        *Token
 	valid        bool
 	Debug        bool
 }
 
 // NewClient returns a Client usable for executing authenticated Auth0 Management API methods
-func NewClient(clientID, clientSecret, audience, endpoint string) (*Client, error) {
-	token, err := GetToken(clientID, clientSecret, audience, endpoint)
+func NewClient(clientID, clientSecret, audience, domain string) (*Client, error) {
+	token, err := GetToken(clientID, clientSecret, audience, domain)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error intializing new Auth0 client")
 	}
@@ -34,7 +34,7 @@ func NewClient(clientID, clientSecret, audience, endpoint string) (*Client, erro
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		Audience:     audience,
-		Endpoint:     endpoint,
+		Domain:       domain,
 		token:        token,
 		valid:        true,
 	}
@@ -53,7 +53,7 @@ func (c *Client) startTokenRefresher() {
 	refresher := time.NewTicker(time.Second * time.Duration(c.token.ExpiresIn-5))
 	go func() {
 		for _ = range refresher.C {
-			token, err := GetToken(c.ClientID, c.ClientSecret, c.Audience, c.Endpoint)
+			token, err := GetToken(c.ClientID, c.ClientSecret, c.Audience, c.Domain)
 			if err != nil {
 				fmt.Printf("Error refreshing Auth0 token: %s", err.Error())
 

--- a/client.go
+++ b/client.go
@@ -17,14 +17,15 @@ type Client struct {
 	ClientID     string
 	ClientSecret string
 	Audience     string
+	Endpoint     string
 	token        *Token
 	valid        bool
 	Debug        bool
 }
 
 // NewClient returns a Client usable for executing authenticated Auth0 Management API methods
-func NewClient(clientID, clientSecret, audience string) (*Client, error) {
-	token, err := GetToken(clientID, clientSecret, audience)
+func NewClient(clientID, clientSecret, audience, endpoint string) (*Client, error) {
+	token, err := GetToken(clientID, clientSecret, audience, endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error intializing new Auth0 client")
 	}
@@ -33,6 +34,7 @@ func NewClient(clientID, clientSecret, audience string) (*Client, error) {
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		Audience:     audience,
+		Endpoint:     endpoint,
 		token:        token,
 		valid:        true,
 	}
@@ -51,7 +53,7 @@ func (c *Client) startTokenRefresher() {
 	refresher := time.NewTicker(time.Second * time.Duration(c.token.ExpiresIn-5))
 	go func() {
 		for _ = range refresher.C {
-			token, err := GetToken(c.ClientID, c.ClientSecret, c.Audience)
+			token, err := GetToken(c.ClientID, c.ClientSecret, c.Audience, c.Endpoint)
 			if err != nil {
 				fmt.Printf("Error refreshing Auth0 token: %s", err.Error())
 

--- a/client.go
+++ b/client.go
@@ -78,8 +78,6 @@ func (c *Client) POST(endpoint string, input interface{}, output interface{}) er
 		return err
 	}
 
-	logrus.WithField("user", output).Info("Raw Output")
-
 	return json.Unmarshal(b, &output)
 }
 
@@ -161,7 +159,11 @@ func (c *Client) request(method, endpoint string, params map[string]string, body
 		fmt.Printf("RESPONSE: %s\n", string(resBody))
 	}
 
-	logrus.WithField("res", res).Info("Response")
+	logrus.WithFields(logrus.Fields{
+		"status code": res.StatusCode,
+		"status":      res.Status,
+		"header":      res.Header,
+	}).Info("Response")
 
 	return resBody, nil
 }

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/Sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -76,6 +77,8 @@ func (c *Client) POST(endpoint string, input interface{}, output interface{}) er
 	if err != nil {
 		return err
 	}
+
+	logrus.WithField("user", output).Info("Raw Output")
 
 	return json.Unmarshal(b, &output)
 }

--- a/token.go
+++ b/token.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -25,12 +24,14 @@ type Token struct {
 //
 // The ClientID and Audience can be found on your Auth0 APIs page, located
 // at https://manage.auth0.com/#/apis/.  (Audience is labeled as Identifier).
-func GetToken(clientID, clientSecret, audience, endpoint string) (*Token, error) {
-	// url, err := authEndpointFromAudience(audience)
+// The Domain can be found on your Auth0 Clients page, located at
+// https://manage.auth0.com/#/clients/ under your Client's "Settings"
+func GetToken(clientID, clientSecret, audience, domain string) (*Token, error) {
+	url, err := authEndpointFromDomain(domain)
 
-	// if err != nil {
-	// 	return nil, errors.Wrap(err, "Error getting token request URL")
-	// }
+	if err != nil {
+		return nil, errors.Wrap(err, "Error getting token request URL")
+	}
 
 	payload := struct {
 		ClientID     string `json:"client_id"`
@@ -49,7 +50,7 @@ func GetToken(clientID, clientSecret, audience, endpoint string) (*Token, error)
 		return nil, errors.Wrap(err, "Error marshalling JSON token request payload")
 	}
 
-	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(b))
+	req, err := http.NewRequest("POST", url, bytes.NewReader(b))
 	if err != nil {
 		return nil, errors.Wrap(err, "Error building token request")
 	}
@@ -79,14 +80,8 @@ func GetToken(clientID, clientSecret, audience, endpoint string) (*Token, error)
 }
 
 // e.g. https://mock.auth0.com/oauth/token from
-// https://mock.auth0.com/api/v2/
-func authEndpointFromAudience(audience string) (string, error) {
-	parts := strings.Split(audience, "/")
-
-	if len(parts) != 6 {
-		return "", fmt.Errorf("Bad Audience URL '%s', should look like 'https://mock.auth0.com/api/v2/'", audience)
-	}
+// mock.auth0.com
+func authEndpointFromDomain(domain string) (string, error) {
 	// TODO: more validations?
-
-	return fmt.Sprintf("%s/oauth/token", strings.Join(parts[0:3], "/")), nil
+	return fmt.Sprintf("https://%s/oauth/token", domain), nil
 }

--- a/token.go
+++ b/token.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -79,9 +80,18 @@ func GetToken(clientID, clientSecret, audience, domain string) (*Token, error) {
 	return &t, nil
 }
 
-// e.g. https://mock.auth0.com/oauth/token from
-// mock.auth0.com
+// e.g. https://mock.auth0.com/oauth/token from mock.auth0.com
 func authEndpointFromDomain(domain string) (string, error) {
+	parts := strings.Split(domain, ".")
+
+	lastIdx := len(parts) - 1
+	end := strings.Join(parts[lastIdx-1:], ".")
+
+	if end != "auth0.com" {
+		return "", fmt.Errorf("Bad Domain URL '%s', should look like 'mock.auth0.com'", domain)
+	}
+
 	// TODO: more validations?
+
 	return fmt.Sprintf("https://%s/oauth/token", domain), nil
 }

--- a/token.go
+++ b/token.go
@@ -25,12 +25,12 @@ type Token struct {
 //
 // The ClientID and Audience can be found on your Auth0 APIs page, located
 // at https://manage.auth0.com/#/apis/.  (Audience is labeled as Identifier).
-func GetToken(clientID, clientSecret, audience string) (*Token, error) {
-	url, err := authEndpointFromAudience(audience)
+func GetToken(clientID, clientSecret, audience, endpoint string) (*Token, error) {
+	// url, err := authEndpointFromAudience(audience)
 
-	if err != nil {
-		return nil, errors.Wrap(err, "Error getting token request URL")
-	}
+	// if err != nil {
+	// 	return nil, errors.Wrap(err, "Error getting token request URL")
+	// }
 
 	payload := struct {
 		ClientID     string `json:"client_id"`
@@ -49,7 +49,7 @@ func GetToken(clientID, clientSecret, audience string) (*Token, error) {
 		return nil, errors.Wrap(err, "Error marshalling JSON token request payload")
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(b))
+	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(b))
 	if err != nil {
 		return nil, errors.Wrap(err, "Error building token request")
 	}

--- a/token_test.go
+++ b/token_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 )
 
-func Test_authEndpointFromAudience(t *testing.T) {
+func Test_authEndpointFromDomain(t *testing.T) {
 	type args struct {
-		audience string
+		domain string
 	}
 	tests := []struct {
 		name    string
@@ -17,7 +17,7 @@ func Test_authEndpointFromAudience(t *testing.T) {
 		{
 			name: "good audience",
 			args: args{
-				audience: "https://mock.auth0.com/api/v2/",
+				domain: "mock.auth0.com",
 			},
 			want:    "https://mock.auth0.com/oauth/token",
 			wantErr: false,
@@ -25,7 +25,7 @@ func Test_authEndpointFromAudience(t *testing.T) {
 		{
 			name: "bad audience",
 			args: args{
-				audience: "https://mock.auth0.com",
+				domain: "mock.com",
 			},
 			want:    "",
 			wantErr: true,
@@ -33,13 +33,13 @@ func Test_authEndpointFromAudience(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := authEndpointFromAudience(tt.args.audience)
+			got, err := authEndpointFromDomain(tt.args.domain)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("authEndpointFromAudience() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("authEndpointFromDomain() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("authEndpointFromAudience() = %v, want %v", got, tt.want)
+				t.Errorf("authEndpointFromDomain() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/user.go
+++ b/user.go
@@ -3,7 +3,6 @@ package auth0
 import (
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 )
 
@@ -54,12 +53,6 @@ func (c *Client) UserCreate(p *UserCreateParams) (*User, error) {
 	if err := c.POST("users", p, &u); err != nil {
 		return nil, errors.Wrap(err, "Error creating user")
 	}
-
-	logrus.WithFields(logrus.Fields{
-		"email": u.Email,
-		"md":    u.UserMetadata,
-		"id":    u.UserID,
-	}).Info("User Created")
 
 	return &u, nil
 }

--- a/user.go
+++ b/user.go
@@ -3,6 +3,7 @@ package auth0
 import (
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 )
 
@@ -53,6 +54,12 @@ func (c *Client) UserCreate(p *UserCreateParams) (*User, error) {
 	if err := c.POST("users", p, &u); err != nil {
 		return nil, errors.Wrap(err, "Error creating user")
 	}
+
+	logrus.WithFields(logrus.Fields{
+		"email": u.Email,
+		"md":    u.UserMetadata,
+		"id":    u.UserID,
+	}).Info("User Created")
 
 	return &u, nil
 }


### PR DESCRIPTION
**Catch response errors**
In the Client request method, catch the error message in the response body returned from Auth0 if an error is returned

**Edit to accommodate local environments**
When using auth0 locally, the client audience is something along the lines of `http://localhost:8080/`, while the endpoint will still be in the format of `https://mock.auth0.com/oauth/token`.

For this case, the `authEndpointFromAudience` function errors out and the `GetToken` function fails.

Proposed solution is to provide the Client domain (found in the settings section of a Client in https://manage.auth0.com/#/clients) as an additional argument to the `NewClient` function.